### PR TITLE
Special attribute for macOS accessibility

### DIFF
--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -72,6 +72,9 @@
     bool enableAccessibility = ([self voiceOverEnabled] && [value boolValue]);
     [self updateAccessibilityEnabled:enableAccessibility];
   }
+  else if ([attribute isEqualToString:@"AXManualAccessibility"]) {
+    [self updateAccessibilityEnabled:[value boolValue]];
+  }
   return [super accessibilitySetValue:value forAttribute:attribute];
 }
 


### PR DESCRIPTION
In the issue 7206 we were discussing that Electron apps are inaccessible unless VoiceOver is enabled. While it's a working solution for users with vision impairment, all other users and apps that require accessibility can't interact with Electron-based software because they don't keep VoiceOver running.

I suggest adding `AXManualAccessibility` for programmatically enabling it in Electron apps. The reason for a new attribute is that `AXEnhancedUserInterface` is already reserved by VoiceOver.

Adding this attribute will allow both Electron developers and 3rd party developers to enable and disable accessibility from their code by calling `accessibilitySetValue:forAttribute:` on the application.

It will be also possible to create a small utility app to switch accessibility in Electron-based apps until there's a native UI solution (like the accessibility settings page in Chrome).